### PR TITLE
Br ap25 issues

### DIFF
--- a/reference-backup-cbs-db-in-dark-site.adoc
+++ b/reference-backup-cbs-db-in-dark-site.adoc
@@ -1,7 +1,7 @@
 ---
 sidebar: sidebar
 permalink: reference-backup-cbs-db-in-dark-site.html
-keywords: backup database, recover database
+keywords: backup database, recover database, dark site, private mode, restore database, backup and recovery, BlueXP Connector
 summary: When using BlueXP backup and recovery in a site with no internet access, known as "private mode", the BlueXP backup and recovery configuration data is backed up to the StorageGRID or ONTAP S3 bucket where your backups are being stored. If you have an issue with the BlueXP Connector host system in the future, you can deploy a new Connector and restore the critical BlueXP backup and recovery data.
 ---
 

--- a/reference-backup-cbs-db-in-dark-site.adoc
+++ b/reference-backup-cbs-db-in-dark-site.adoc
@@ -125,15 +125,15 @@ Add the details of the StorageGRID system associated with your ONTAP working env
 
 The following information applies to private mode installations starting from BlueXP 3.9.xx. For older versions, use the following procedure: https://community.netapp.com/t5/Tech-ONTAP-Blogs/DarkSite-Cloud-Backup-MySQL-and-Indexed-Catalog-Backup-and-Restore/ba-p/440800[DarkSite Cloud Backup: MySQL and Indexed Catalog Backup and Restore^].
 
-You'll need to perform these steps for each ONTAP system that is backing up data to StorageGRID.
+You'll need to perform these steps for each system that is backing up data to StorageGRID.
 
 . Extract the authorization token using the following oauth/token API.
 +
 [source,http]
-curl 'http://10.193.192.202/oauth/token' -X POST -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:100101 Firefox/108.0' -H 'Accept: application/json' -H 'Accept-Language: en-US,en;q=0.5' -H 'Accept-Encoding: gzip, deflate' -H 'Content-Type: application/json' -d '{"username":"admin@netapp.com","password":"Netapp@123","grant_type":"password"}
+curl 'http://10.193.192.202/oauth/token' -X POST -H 'Accept: application/json' -H 'Accept-Language: en-US,en;q=0.5' -H 'Accept-Encoding: gzip, deflate' -H 'Content-Type: application/json' -d '{"username":"admin@netapp.com","password":"Netapp@123","grant_type":"password"}
 > '
 +
-While the IP address, username, and passwords are custom values, the account name is not. The account name is always "account-DARKSITE1".
+While the IP address, username, and passwords are custom values, the account name is not. The account name is always "account-DARKSITE1". Also, the username must use an email-formatted name. 
 +
 This API will return a response like the following. You can retrieve the authorization token as shown below.
 +


### PR DESCRIPTION
Jira tickets 388, 435
This pull request updates the documentation for backing up the BlueXP database in a dark site environment. The changes include enhancing keyword metadata, clarifying instructions, and improving the example API usage.

### Documentation Enhancements:

* **Improved keyword metadata**: Added new keywords such as "dark site," "private mode," "restore database," and "BlueXP Connector" to improve searchability and relevance for users working in private mode environments. (`reference-backup-cbs-db-in-dark-site.adoc`, [reference-backup-cbs-db-in-dark-site.adocL4-R4](diffhunk://#diff-4d1f1fa6f63bab24baabfe55fed4a369046426ebed49803fc47f02dc8748f021L4-R4))

* **Clarified instructions for StorageGRID systems**: Updated the phrasing to generalize the steps for all systems backing up to StorageGRID, rather than limiting it to ONTAP systems. (`reference-backup-cbs-db-in-dark-site.adoc`, [reference-backup-cbs-db-in-dark-site.adocL128-R136](diffhunk://#diff-4d1f1fa6f63bab24baabfe55fed4a369046426ebed49803fc47f02dc8748f021L128-R136))

### Example API Usage Improvements:

* **Simplified API headers**: Removed unnecessary `User-Agent` header from the example `curl` command to streamline the API request. (`reference-backup-cbs-db-in-dark-site.adoc`, [reference-backup-cbs-db-in-dark-site.adocL128-R136](diffhunk://#diff-4d1f1fa6f63bab24baabfe55fed4a369046426ebed49803fc47f02dc8748f021L128-R136))

* **Additional username guidance**: Added clarification that the username must be in an email format when using the `oauth/token` API. (`reference-backup-cbs-db-in-dark-site.adoc`, [reference-backup-cbs-db-in-dark-site.adocL128-R136](diffhunk://#diff-4d1f1fa6f63bab24baabfe55fed4a369046426ebed49803fc47f02dc8748f021L128-R136))