### PR TITLE
Br release june2025

### DIFF
--- a/_whatsnew/2025-06-09.adoc
+++ b/_whatsnew/2025-06-09.adoc
@@ -18,8 +18,7 @@ For more information, see https://docs.netapp.com/us-en/bluexp-backup-recovery/t
 
 Typically, BlueXP backup and recovery establishes a private endpoint with the cloud provider to handle various protection tasks. This release introduces an optional setting that lets you enable or disable BlueXP backup and recovery from automatically creating a private endpoint. This might be useful to you if you want more control over the private endpoint creation process.
 
-
-//You can enable or disable this setting in the BlueXP backup and recovery Settings page. If you disable this setting, you must manually create the private endpoint for BlueXP backup and recovery to function properly.
+You can enable or disable this option when you enable protection or starting the restore process. 
 
 If you disable this setting, you must manually create the private endpoint for BlueXP backup and recovery to function properly. Without proper connectivity, you might not be able to perform backup and recovery tasks successfully.
 

--- a/task-restore-backups-ontap.adoc
+++ b/task-restore-backups-ontap.adoc
@@ -633,17 +633,19 @@ The Indexed Catalog v2 supports the following:
 
 .Enabling the Indexed Catalog for a working environment
 
-When you enable this functionality, BlueXP backup and recovery enables SnapDiff v3 on the SVM for your volumes, and it performs the following actions:
+The service does not provision a separate bucket when you use the Indexed Catalog v2. Instead, for backups stored in AWS, Azure, Google Cloud Platform, StorageGRID, or ONTAP S3, the service provisions space on the Connector or on the cloud provider environment. 
 
-ifdef::aws[]
+If you enabled the Indexed Catalog prior to the v2 release, the following occurs with working environments: 
+
+
 * For backups stored in AWS, it provisions a new S3 bucket and the https://aws.amazon.com/athena/faqs/[Amazon Athena interactive query service^] and https://aws.amazon.com/glue/faqs/[AWS Glue serverless data integration service^].
-endif::aws[]
-ifdef::azure[]
+
+
 * For backups stored in Azure, it provisions an Azure Synapse workspace and a Data Lake file system as the container that will store the workspace data.
-endif::azure[]
-ifdef::gcp[]
+
+
 * For backups stored in Google Cloud, it provisions a new bucket, and the https://cloud.google.com/bigquery[Google Cloud BigQuery services^] are provisioned on an account/project level.
-endif::gcp[]
+
 * For backups stored in StorageGRID or ONTAP S3, it provisions space on the Connector, or on the cloud provider environment.
 
 If Indexing has already been enabled for your working environment, go to the next section to restore your data.

--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -4,7 +4,7 @@ permalink: whats-new.html
 keywords: what's new, features, new, release notes, bugs, limitations, known issues, enhancements, fixes, backup, restore, bluexp, bluexp backup and recovery, protection
 summary: Learn what's new in BlueXP backup and recovery.
 ---
-= What's new with BlueXP backup and recovery
+= What's new in BlueXP backup and recovery
 :hardbreaks:
 :nofooter:
 :icons: font


### PR DESCRIPTION
Restore > Index catalog v2 updates

This pull request updates documentation for BlueXP backup and recovery, focusing on improved clarity and accuracy regarding new features and functionality. The most important changes include updates to private endpoint configuration, Indexed Catalog v2 provisioning, and a minor title adjustment for consistency.

### Documentation Updates:

* **Private Endpoint Configuration**:
  - Updated the description of private endpoint settings to clarify that users can enable or disable this option during protection or restore processes, replacing an outdated reference to the Settings page. (`_whatsnew/2025-06-09.adoc`)

* **Indexed Catalog v2 Provisioning**:
  - Revised the explanation of how the Indexed Catalog v2 provisions resources, specifying that separate buckets are not created for backups in various environments. Added details about changes for environments where the Indexed Catalog was enabled prior to the v2 release. (`task-restore-backups-ontap.adoc`)

### Minor Adjustments:

* **Title Consistency**:
  - Changed the title from "What's new with BlueXP backup and recovery" to "What's new in BlueXP backup and recovery" for improved consistency and readability. (`whats-new.adoc`)