### PR TITLE
Hotfix: Policies updates.

### DIFF
--- a/br-use-policies-create.adoc
+++ b/br-use-policies-create.adoc
@@ -76,11 +76,11 @@ image:screen-br-policies-new-nodata.png[Screenshot of new policy creation]
 
 
 ** *Local snapshot*: Local snapshot on the selected volume. Local snapshots are a key component of data protection strategies, capturing the state of your data at specific points in time. This creates read-only, point-in-time copies of production volumes where your workloads are running. The snapshot consumes minimal storage space and incurs negligible performance overhead because it records only changes to files since the last snapshot. You can use local snapshots to recover from data loss or corruption, as well as to create backups for disaster recovery purposes.
-** *3-2-1 fanout*: Primary storage (disk) to secondary storage (disk) to cloud (object store). Creates multiple copies of data across different storage systems, such as ONTAP to ONTAP and ONTAP to object-store configurations. This can be a cloud hyperscaler object store or a private object store -- StorageGRID. These configurations help in achieving optimal data protection and disaster recovery.
-** *3-2-1 cascaded*: Primary storage (disk) to secondary storage (disk) and primary storage (disk) to cloud storage (object store). This can be a cloud hyperscaler object store or a private object store -- StorageGRID. This creates a chain of data replication across multiple systems to ensure redundancy and reliability. 
-** *Disk to disk*: Primary storage (disk) to secondary storage (disk). The ONTAP to ONTAP data protection strategy replicates data between two ONTAP systems to ensure high availability and disaster recovery. This is typically achieved using SnapMirror, which supports both synchronous and asynchronous replication. This method ensures that your data is continuously updated and available across multiple locations, providing robust protection against data loss. 
+** *3-2-1 fanout*: (Not available for Kubernetes workloads) Primary storage (disk) to secondary storage (disk) to cloud (object store). Creates multiple copies of data across different storage systems, such as ONTAP to ONTAP and ONTAP to object-store configurations. This can be a cloud hyperscaler object store or a private object store -- StorageGRID. These configurations help in achieving optimal data protection and disaster recovery.
+** *3-2-1 cascaded*: (Not available for Kubernetes workloads) Primary storage (disk) to secondary storage (disk) and primary storage (disk) to cloud storage (object store). This can be a cloud hyperscaler object store or a private object store -- StorageGRID. This creates a chain of data replication across multiple systems to ensure redundancy and reliability. 
+** *Disk to disk*: (Not available for Kubernetes workloads) Primary storage (disk) to secondary storage (disk). The ONTAP to ONTAP data protection strategy replicates data between two ONTAP systems to ensure high availability and disaster recovery. This is typically achieved using SnapMirror, which supports both synchronous and asynchronous replication. This method ensures that your data is continuously updated and available across multiple locations, providing robust protection against data loss. 
 ** *Disk-to-object store*: Primary storage (disk) to cloud (object store). This replicates data from an ONTAP system to an object storage system, such as AWS S3, Azure Blob Storage or StorageGRID. This is typically achieved using SnapMirror Cloud, which provides incremental forever backups by transferring only changed data blocks after the initial baseline transfer. This can be a cloud hyperscaler object store or a private object store -- StorageGRID. This method is ideal for long-term data retention and archiving, offering a cost-effective and scalable solution for data protection.
-** *Disk-to-disk fanout*: Primary storage (disk) to secondary storage (disk)  and primary storage (disk) to secondary storage (disk). 
+** *Disk-to-disk fanout*: (Not available for Kubernetes workloads) Primary storage (disk) to secondary storage (disk)  and primary storage (disk) to secondary storage (disk). 
 +
 NOTE: You can configure multiple secondary settings for the disk-to-disk fanout option. 
 
@@ -111,7 +111,7 @@ Provide information for the local snapshot.
 
 === Create a policy for secondary settings (replication to secondary storage)
 
-Provide information for the replication to secondary storage. Schedule information from the local snapshot settings appears for you in the secondary settings. These settings are not availabe for Kubernetes workloads.
+Provide information for the replication to secondary storage. Schedule information from the local snapshot settings appears for you in the secondary settings. These settings are not available for Kubernetes workloads.
 
 * *Backup*: Select the frequency of hourly, daily, weekly, monthly, or yearly. 
 * *Backup target*: Select the target system on secondary storage for the backup.


### PR DESCRIPTION
This pull request updates the documentation in `br-use-policies-create.adoc` to clarify which data protection strategies are not available for Kubernetes workloads and corrects a minor typo. The main focus is on improving the accuracy and clarity of the information presented to users.

**Documentation updates for Kubernetes workload support:**

* Added explicit notes to the descriptions of `3-2-1 fanout`, `3-2-1 cascaded`, `Disk to disk`, and `Disk-to-disk fanout` strategies indicating that these options are not available for Kubernetes workloads. This helps users quickly identify which backup and replication strategies are supported for their environment.

**Minor corrections:**

* Fixed a typo in the phrase "not availabe for Kubernetes workloads" to "not available for Kubernetes workloads" for improved readability and professionalism.