### PR TITLE
Fixed wording of learn about to include K8s.

### DIFF
--- a/concept-backup-to-cloud.adoc
+++ b/concept-backup-to-cloud.adoc
@@ -13,7 +13,7 @@ summary: The BlueXP backup and recovery service provides efficient, secure, and 
 :imagesdir: ./media/
 
 [.lead]
-The BlueXP backup and recovery service provides efficient, secure, and cost-effective data protection for ONTAP volumes, Microsoft SQL Server instances and databases (Preview), and VMware workloads. 
+The BlueXP backup and recovery service provides efficient, secure, and cost-effective data protection for ONTAP volumes, Microsoft SQL Server instances and databases (Preview), VMware workloads, and Kubernetes workloads (Preview).
 
 NOTE: This documentation is provided as a technology preview. With this preview offering, NetApp reserves the right to modify offering details, contents, and timeline before General Availability.   
 
@@ -164,7 +164,7 @@ When you use GCP, you can request a private offer from NetApp, and then select t
 
 .Workload data sources supported
 
-The service protects the following application-based workloads:
+The service protects the following workloads:
 
 //* NetApp file shares
 * ONTAP volumes 


### PR DESCRIPTION
This pull request updates the documentation for the BlueXP backup and recovery service to reflect expanded workload support and clarify terminology. The most important changes are summarized below.

Expanded workload support:

* Updated the summary in `concept-backup-to-cloud.adoc` to include Kubernetes workloads (Preview) as a supported data protection target, alongside ONTAP volumes, Microsoft SQL Server instances and databases, and VMware workloads.

Terminology clarification:

* Revised the description in `concept-backup-to-cloud.adoc` to refer to "workloads" instead of "application-based workloads," making the supported data sources list more inclusive and general.