### PR TITLE
HOTFIX: Clarify mention of data services roles for Kubernetes workloads.

### DIFF
--- a/br-start-discover-kubernetes.adoc
+++ b/br-start-discover-kubernetes.adoc
@@ -16,7 +16,7 @@ summary: The BlueXP backup and recovery service needs to first discover workload
 The BlueXP backup and recovery service needs to first discover Kubernetes workloads in order for you to use the service. 
 
 *Required BlueXP role*
-Backup and Recovery super admin. Learn about link:reference-roles.html[Backup and recovery roles and privileges]. https://docs.netapp.com/us-en/bluexp-setup-admin/reference-iam-predefined-roles.html[Learn about BlueXP access roles for all services^].
+This task requires the data services Backup and recovery super admin role. Learn about link:reference-roles.html[Backup and recovery data services roles and privileges]. https://docs.netapp.com/us-en/bluexp-setup-admin/reference-iam-predefined-roles.html[Learn about BlueXP access roles for all services^].
 
 
 == Discover Kubernetes workloads

--- a/br-start-discover.adoc
+++ b/br-start-discover.adoc
@@ -19,7 +19,7 @@ The BlueXP backup and recovery service needs to first discover Microsoft SQL Ser
 //* <<Discover Kubernetes workloads>>
 
 *Required BlueXP role*
-Backup and Recovery super admin. Learn about link:reference-roles.html[Backup and recovery roles and privileges]. https://docs.netapp.com/us-en/bluexp-setup-admin/reference-iam-predefined-roles.html[Learn about BlueXP access roles for all services^].
+This task requires the data services Backup and recovery super admin role. Learn about link:reference-roles.html[Backup and recovery data services roles and privileges]. https://docs.netapp.com/us-en/bluexp-setup-admin/reference-iam-predefined-roles.html[Learn about BlueXP access roles for all services^].
 
 
 


### PR DESCRIPTION
Fixes #258 
This pull request updates the documentation to clarify the required BlueXP role for discovering workloads in the backup and recovery service. The changes improve the description of the necessary permissions and provide more accurate links to role information.

Documentation updates:

* Updated the required BlueXP role description in both `br-start-discover-kubernetes.adoc` and `br-start-discover.adoc` to specify that the "data services Backup and recovery super admin" role is needed, and clarified the link text regarding roles and privileges. [[1]](diffhunk://#diff-98a2a15d2d321ea44020bcfc45f673ac71a4b9b7706669beb2aca26e4fc64b09L19-R19) [[2]](diffhunk://#diff-98d07fddd6075af1c9c3b5a70e6c401c4b7b6aab5a695fca31ef85a482e7b214L22-R22)