### PR TITLE
Hotfix for review comments for policy creation.

### DIFF
--- a/br-use-policies-create.adoc
+++ b/br-use-policies-create.adoc
@@ -95,7 +95,7 @@ Provide information for the local snapshot.
 * *Snapshot retention*: Enter the number of snapshots to keep.
 * *Enable log backup*: (Not available for Kubernetes workloads) Check the option to back up logs and set the frequency and retention of the log backups. To do this, you must have already configured a log backup. See link:br-start-configure.html[Configure log directories].
 * *Provider*: (Kubernetes workloads only) Select the storage provider that hosts the Kubernetes application resources.
-* *Backup target*: (Kubernetes workloads only) Select the target system for the backup. This is the storage system where the snapshots will be stored. Ensure that the target is accessible within your backup environment.
+* *Backup target*: (Kubernetes workloads only) Select the storage bucket that hosts the Kubernetes application resources. The snapshots will be stored in this bucket. Ensure that the bucket is accessible within your backup environment.
 
 * Optionally, select *Advanced* at the right of the schedule to set the SnapMirror label and enable snapshot locking (not available for Kubernetes workloads). 
 

--- a/br-use-protect-kubernetes-applications.adoc
+++ b/br-use-protect-kubernetes-applications.adoc
@@ -44,7 +44,7 @@ Before you can add and protect a Kubernetes application, you need to link:br-sta
 NOTE: BlueXP does not store the search parameters or results; the parameters are used to search the selected Kubernetes cluster for resources that can be included in the application. 
 . BlueXP displays a list of resources that match your search criteria.
 . If the list contains the resources you want to protect, select *Next*.
-. Optionally, in the *Policy* area, choose an existing protection policy to protect the application or create a new policy. If you don't select a policy, the application is created without a protection policy. You can add a policy later.
+. Optionally, in the *Policy* area, choose an existing protection policy to protect the application or create a new policy. If you don't select a policy, the application is created without a protection policy. You can link:br-use-policies-create.html#create-a-policy[add a protection policy] later.
 . In the *Prescripts and postscripts* area, enable and configure any prescript or postscript execution hooks that you want to run before or after backup operations. To enable prescripts or postscripts, you must have already created at least one link:br-use-manage-execution-hook-templates.html[execution hook template].
 . Select *Create*.
 
@@ -60,7 +60,7 @@ Enable a protection policy on a Kubernetes application that you have already add
 . Select the *Applications* tab.
 . In the list of applications, choose an application you want to protect and select the associated Actions menu.
 . Select *Protect*.
-. In the *Policy* area, choose an existing protection policy to protect the application or create a new policy.
+. In the *Policy* area, choose an existing protection policy to protect the application or create a new policy. Refer to link:br-use-policies-create.html#create-a-policy[Create a protection policy] for information on creating protection policies.
 . In the *Prescripts and postscripts* area, enable and configure any prescript or postscript execution hooks that you want to run before or after backup operations. You can configure the type of execution hook, the template it uses, arguments, and label selectors.
 . Select *Done*.
 


### PR DESCRIPTION
This pull request updates the documentation for Kubernetes application protection workflows to clarify terminology and provide more direct links to related instructions. The main improvements focus on making it easier for users to understand the backup target concept and to find information about creating and applying protection policies.

Documentation clarity and usability improvements:

* Updated the description of the "Backup target" for Kubernetes workloads to specify that it refers to the storage bucket hosting application resources, and clarified where snapshots are stored.
* Enhanced guidance on applying protection policies by adding direct links to instructions for creating a protection policy when adding or protecting a Kubernetes application. [[1]](diffhunk://#diff-45399f388bd42e7b3ab295781925fdf4286d4f3fc726306a8d7d18e7cc99b121L47-R47) [[2]](diffhunk://#diff-45399f388bd42e7b3ab295781925fdf4286d4f3fc726306a8d7d18e7cc99b121L63-R63)