### PR TITLE
Bluexpdoc 845 br monitor

### DIFF
--- a/br-use-monitor-tasks.adoc
+++ b/br-use-monitor-tasks.adoc
@@ -15,6 +15,8 @@ summary: With BlueXP backup and recovery, monitor the status of local Snapshots,
 [.lead]
 With BlueXP backup and recovery, monitor the status of local snapshots, replications, and backup to object storage jobs that you initiated, and restore jobs that you initiated. You can see the jobs that have completed, are in progress, or failed so you can diagnose and fix problems. Using the BlueXP Notification Center, you can enable notifications to be sent by email so you can be informed of important system activity even when you're not logged into the system. Using the BlueXP Timeline, you can see details of all actions initiated via the UI or API.
 
+BlueXP backup and recovery retains job information for 15 days, after which it is purged and no longer visible in the Job Monitor. 
+
 *Required BlueXP role*
 Organization admin, Folder or project admin, Backup and Recovery super admin, Backup and Recovery backup admin, Backup and Recovery restore admin, Backup and Recovery clone admin, or Backup and Recovery viewer role. Learn about link:reference-roles.html[Backup and recovery roles and privileges]. https://docs.netapp.com/us-en/bluexp-setup-admin/reference-iam-predefined-roles.html[Learn about BlueXP access roles for all services^]. 
 


### PR DESCRIPTION
This pull request adds a clarification about how long BlueXP backup and recovery retains job information. Now, users are informed that job information is only available for 15 days before being purged from the Job Monitor.

Documentation update:

* Added a note that BlueXP backup and recovery retains job information for 15 days, after which it is purged and no longer visible in the Job Monitor (`br-use-monitor-tasks.adoc`).