### PR TITLE
Bluexpdoc 796 br objectstore datalock

### DIFF
--- a/br-start-licensing.adoc
+++ b/br-start-licensing.adoc
@@ -38,8 +38,7 @@ When you end the free trial without subscribing to a paid plan, your data is aut
 
 .Steps
 . From the BlueXP backup and recovery landing page, select *View free trial*.
-+
-*QUESTION TO REVIEWERS*: How do users get to the Landing page if they're on other BR pages? 
+
 . Select *End free trial*.
 . Select *Delete data immediately after ending my free trial* to delete your data immediately.
 . Type *end trial* in the box. 

--- a/prev-ontap-policy-object-options.adoc
+++ b/prev-ontap-policy-object-options.adoc
@@ -60,7 +60,7 @@ This feature does not provide protection for your source volumes; only for the b
 
 [CAUTION]
 ====
-* If you plan to use DataLock and Ransomware protection, you can enable it when creating your first backup policy and activating BlueXP backup and recovery for that cluster. You can later enable or disable ransomware scanning using BlueXP backup and recovery Advanced Settings. 
+* If you plan to use DataLock and Ransomware protection, you can enable it when creating your first backup policy and activating BlueXP backup and recovery for that cluster. You can later enable or disable Ransomware scanning using BlueXP backup and recovery Advanced Settings. 
 * When BlueXP scans a backup file for ransomware when restoring volume data, you'll incur extra egress costs from your cloud provider to access the contents of the backup file.
 ====
 
@@ -121,9 +121,9 @@ Refer to link:prev-ontap-policy-object-advanced-settings.html[How to update Rans
 
 
 
-=== What is Ransomware protection
+=== What is Ransomware protection in NetApp Backup and Recovery
 
-Ransomware protection scans your backup files to look for evidence of a ransomware attack. The detection of ransomware attacks is performed using a checksum comparison. If potential ransomware is identified in a new backup file versus the previous backup file, that newer backup file is replaced by the most recent backup file that does not show any signs of a ransomware attack. (The file that was identified as having a ransomware attack is deleted 1 day after it has been replaced.)
+The Ransomware protection option in NetApp Backup and Recovery scans your backup files to look for evidence of a ransomware attack. The detection of ransomware attacks is performed using a checksum comparison. If potential ransomware is identified in a new backup file versus the previous backup file, that newer backup file is replaced by the most recent backup file that does not show any signs of a ransomware attack. (The file that was identified as having a ransomware attack is deleted 1 day after it has been replaced.)
 
 Scans occur in these situations:
 
@@ -277,7 +277,7 @@ endif::azure[]
 * The DataLock option you select when activating BlueXP backup and recovery must be used for all backup policies for that cluster. 
 * You cannot use multiple DataLock modes on a single cluster.
 * If you enable DataLock, all volume backups will be locked. You can't mix locked and non-locked volume backups for a single cluster.
-* DataLock and Ransomware protection is applicable for new volume backups using a backup policy with DataLock and Ransomware protection enabled. You can later enable or disable these features using the Advanced Settings option. 
+* DataLock and Ransomware protection is applicable for new volume backups using a backup policy with DataLock and Ransomware protection enabled. You can later enable or disable the Ransomware scanning option using the Advanced Settings option. 
 * FlexGroup volumes can use DataLock and Ransomware protection only when using ONTAP 9.13.1 or greater.
 
 === Tips on how to mitigate DataLock costs


### PR DESCRIPTION
This pull request makes several documentation improvements related to DataLock and Ransomware protection features in NetApp Backup and Recovery. The changes focus on clarifying terminology and improving feature descriptions. This request also makes a minor editing change to the Licensing topic. 

**Feature terminology and clarity:**

* Standardized the capitalization and naming of "Ransomware scanning" and "Ransomware protection" throughout the documentation for consistency and clarity. [[1]](diffhunk://#diff-75da5083296714f058cff2c806080466f33bb3ac7b7e2ef03022c59bdb7030f9L63-R63) [[2]](diffhunk://#diff-75da5083296714f058cff2c806080466f33bb3ac7b7e2ef03022c59bdb7030f9L280-R280)
* Updated section heading and introductory text to explicitly state that Ransomware protection is a feature of NetApp Backup and Recovery, improving context for users.

